### PR TITLE
[CMake] Encapsulate the disassembly generation in a reusable CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 find_package(Boost 1.62.0 EXACT)
 if (Boost_INCLUDE_DIRS)

--- a/cmake/Disassemble.cmake
+++ b/cmake/Disassemble.cmake
@@ -1,0 +1,71 @@
+# Copyright Louis Dionne 2016
+# Copyright Zach Laine 2016
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+#
+#
+# This CMake module provides a way to get the disassembly of a function within
+# an executable created with `add_executable`. The module provides a `disassemble`
+# function that creates a target which, when built, outputs the disassembly of
+# the given function within an executable to standard output.
+#
+# Parameters
+# ----------
+# target:
+#   The name of the target to create. Building this target will generate the
+#   requested disassembly.
+#
+# EXECUTABLE executable:
+#   The name of an executable to disassemble. This must be the name of a valid
+#   executable that was created with `add_executable`. The disassembly target
+#   thus created will be made dependent on the executable, so that it is built
+#   automatically when the disassembly is requested.
+#
+# FUNCTION function-name:
+#   The name of the function to disassemble in the executable.
+#
+# [ALL]:
+#   If provided, the generated target is included in the 'all' target.
+#
+function(disassemble target)
+  cmake_parse_arguments(ARGS "ALL"                 # options
+                             "EXECUTABLE;FUNCTION" # 1 value args
+                             ""                    # multivalued args
+                             ${ARGN})
+
+  if (NOT ARGS_EXECUTABLE)
+    message(FATAL_ERROR "The `EXECUTABLE` argument must be provided.")
+  endif()
+  if (NOT TARGET ${ARGS_EXECUTABLE})
+    message(FATAL_ERROR "The `EXECUTABLE` argument must be the name of a valid "
+                        "executable created with `add_executable`.")
+  endif()
+
+  if (NOT ARGS_FUNCTION)
+    message(FATAL_ERROR "The `FUNCTION` argument must be provided.")
+  endif()
+
+  if (ARGS_ALL)
+    set(ARGS_ALL "ALL")
+  else()
+    set(ARGS_ALL "")
+  endif()
+
+  if (DISASSEMBLE_lldb)
+    add_custom_target(${target} ${ARGS_ALL}
+      COMMAND ${DISASSEMBLE_lldb} -f $<TARGET_FILE:${ARGS_EXECUTABLE}>
+                                  -o "disassemble --name ${ARGS_FUNCTION}"
+                                  -o quit
+      DEPENDS ${ARGS_EXECUTABLE}
+    )
+  elseif(DISASSEMBLE_gdb)
+    add_custom_target(${target} ${ARGS_ALL}
+      COMMAND ${DISASSEMBLE_gdb} -batch -se $<TARGET_FILE:${ARGS_EXECUTABLE}>
+                                 -ex "disassemble ${ARGS_FUNCTION}"
+      DEPENDS ${ARGS_EXECUTABLE}
+    )
+  endif()
+endfunction()
+
+find_program(DISASSEMBLE_gdb gdb)
+find_program(DISASSEMBLE_lldb lldb)

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_program(lldb lldb)
-find_program(gdb gdb)
-
 include_directories(${CMAKE_HOME_DIRECTORY})
 include_directories(${CMAKE_HOME_DIRECTORY}/benchmark-v1.1.0/include)
 
@@ -27,37 +24,23 @@ endmacro()
 add_perf_executable(map_assign_perf)
 add_perf_executable(arithmetic_perf)
 
+include(Disassemble)
+foreach(fun eval_as_cpp_expr eval_as_yap_expr eval_as_cpp_expr_4x eval_as_yap_expr_4x)
+    disassemble(disassemble.arithmetic_perf.${fun} EXECUTABLE arithmetic_perf FUNCTION ${fun})
+    disassemble(disassemble.code_gen_samples.${fun} EXECUTABLE code_gen_samples FUNCTION ${fun})
+endforeach()
 
-if (lldb)
-    add_custom_target(
-        perf
-            COMMAND lldb -f $<TARGET_FILE:arithmetic_perf> -o "disassemble --name eval_as_cpp_expr" -o quit
-            COMMAND lldb -f $<TARGET_FILE:arithmetic_perf> -o "disassemble --name eval_as_yap_expr" -o quit
-            COMMAND lldb -f $<TARGET_FILE:arithmetic_perf> -o "disassemble --name eval_as_cpp_expr_4x" -o quit
-            COMMAND lldb -f $<TARGET_FILE:arithmetic_perf> -o "disassemble --name eval_as_yap_expr_4x" -o quit
+add_custom_target(perf
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.arithmetic_perf.eval_as_cpp_expr
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.arithmetic_perf.eval_as_yap_expr
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.arithmetic_perf.eval_as_cpp_expr_4x
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.arithmetic_perf.eval_as_yap_expr_4x
 
-            COMMAND lldb -f $<TARGET_FILE:code_gen_samples> -o "disassemble --name eval_as_cpp_expr" -o quit
-            COMMAND lldb -f $<TARGET_FILE:code_gen_samples> -o "disassemble --name eval_as_yap_expr" -o quit
-            COMMAND lldb -f $<TARGET_FILE:code_gen_samples> -o "disassemble --name eval_as_cpp_expr_4x" -o quit
-            COMMAND lldb -f $<TARGET_FILE:code_gen_samples> -o "disassemble --name eval_as_yap_expr_4x" -o quit
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.code_gen_samples.eval_as_cpp_expr
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.code_gen_samples.eval_as_yap_expr
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.code_gen_samples.eval_as_cpp_expr_4x
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.code_gen_samples.eval_as_yap_expr_4x
 
-            COMMAND map_assign_perf
-            COMMAND arithmetic_perf
-    )
-elseif (gdb)
-    add_custom_target(
-        perf
-            COMMAND gdb -se $<TARGET_FILE:arithmetic_perf> -batch -ex "disassemble eval_as_cpp_expr"
-            COMMAND gdb -se $<TARGET_FILE:arithmetic_perf> -batch -ex "disassemble eval_as_yap_expr"
-            COMMAND gdb -se $<TARGET_FILE:arithmetic_perf> -batch -ex "disassemble eval_as_cpp_expr_4x"
-            COMMAND gdb -se $<TARGET_FILE:arithmetic_perf> -batch -ex "disassemble eval_as_yap_expr_4x"
-
-            COMMAND gdb -se $<TARGET_FILE:code_gen_samples> -batch -ex "disassemble eval_as_cpp_expr"
-            COMMAND gdb -se $<TARGET_FILE:code_gen_samples> -batch -ex "disassemble eval_as_yap_expr"
-            COMMAND gdb -se $<TARGET_FILE:code_gen_samples> -batch -ex "disassemble eval_as_cpp_expr_4x"
-            COMMAND gdb -se $<TARGET_FILE:code_gen_samples> -batch -ex "disassemble eval_as_yap_expr_4x"
-
-            COMMAND map_assign_perf
-            COMMAND arithmetic_perf
-    )
-endif()
+    COMMAND map_assign_perf
+    COMMAND arithmetic_perf
+)


### PR DESCRIPTION
I did this because I think a general CMake module to get disassembly is useful, and I might need it for Hana. If you don't like the idea, just discard the PR.

Note that depending on the way you're using the disassembly-generating targets, we could also just make them dependencies of the `perf` target and get rid of this list of
```cmake
COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target disassemble.eval_as_cpp_expr
```